### PR TITLE
use splited message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def fread(fname):
 
 
 setup(name='flask_slackbot',
-      version='0.1.8',
+      version='0.1.9',
       url='https://github.com/python-cn/flask-slackbot',
       license='MIT',
       author='halfcrazy',


### PR DESCRIPTION
目前使用私聊会因为post的数据太长被返回414.

``` python
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>414 Request-URI Too Large</title>
</head><body>
<h1>Request-URI Too Large</h1>
<p>The requested URL's length exceeds the capacity
limit for this server.<br />
</p>
</body></html>
```
