### PR TITLE
remove check outgoing"s token

### DIFF
--- a/flask_slackbot/base.py
+++ b/flask_slackbot/base.py
@@ -5,8 +5,6 @@ from functools import partial
 from flask import current_app, Blueprint, request, jsonify, make_response
 from slacker import Slacker
 
-from .exceptions import SlackTokenError
-
 
 default_response = partial(make_response, '', 200)
 MAX_LENGTH = 1000
@@ -20,7 +18,6 @@ class SlackBot(object):
             self.init_app(app)
 
     def init_app(self, app):
-        self.slack_token = app.config.get('SLACK_TOKEN')
         self.slack_chat_token = app.config.get('SLACK_CHAT_TOKEN')
 
         if self.slack_chat_token:
@@ -58,12 +55,6 @@ class SlackBot(object):
 
         if hasattr(self, '_filter') and self._filter(text):
             return default_response()
-
-        try:
-            if token != current_app.config.get('SLACK_TOKEN'):
-                raise SlackTokenError('unmatch token')
-        except SlackTokenError as e:
-            return jsonify({'text': e.msg})
 
         '''
         use flag to determine whether response directly,

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def fread(fname):
 
 
 setup(name='flask_slackbot',
-      version='0.1.9',
+      version='0.2.0',
       url='https://github.com/python-cn/flask-slackbot',
       license='MIT',
       author='halfcrazy',

--- a/tests/test_slackbot.py
+++ b/tests/test_slackbot.py
@@ -50,24 +50,3 @@ def test_response_directly(app):
         assert json.loads(rv.data)['text'] == 'test'
     else:
         assert json.loads(rv.data.decode())['text'] == 'test'
-
-
-def test_invalid_token(app):
-    rv = app.client.post('/slack_callback', data={
-        'token': 'unmatch token',
-        'text': 'test',
-        'team_id': 'team_id',
-        'team_domain': 'team_domain',
-        'channel_id': 'channel_id',
-        'channel_name': 'channel_name',
-        'timestamp': 'timestamp',
-        'user_id': 'user_id',
-        'user_name': 'user_name',
-        'trigger_word': 'trigger_word'
-    })
-
-    assert rv.status_code == 200
-    if sys.version_info.major == 2:
-        assert json.loads(rv.data)['text'] == 'unmatch token'
-    else:
-        assert json.loads(rv.data.decode())['text'] == 'unmatch token'


### PR DESCRIPTION
@halfcrazy  现在有个问题. 假如有其他的人在玩我们的slack-bot 但是没有自己启动服务改token(其实一般人都很懒) 就会这样:

unmatch token

我觉得可以不去检查这个token的限制 而且实际outgoing的过程中也不涉及token的不同
